### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist
 
 # Test
 coverage
+
+# ignore lockfiles other than pnpm's
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This PR updates `.gitignore` so no lockfiles other than pnpm's are pushed